### PR TITLE
Deleted annoying console.error

### DIFF
--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -26,7 +26,6 @@ export const isConditionPassed =
   (app: ZoVueElement, condition: string | Function) =>
   (el: HTMLElement, binding: Binding) => {
     if (!binding.value) {
-      console.error('You must specify a value in the directive.');
       return;
     }
 


### PR DESCRIPTION
This eliminates the annoying `console.error` when the directive has empty permissions

For example in real cases you could use dynamic permissions that a certain element could have for example in the sidebar of a dashboard, executing `menuItem.permissions.join('|')` would obtain the permissions that a user needs to be able to see that permission in the sidebar. For example `'can view invoices'`, but if the result returns empty then it will give an error in console, if it is empty it would mean that any person could see it, and this would be ideal to be able to do it without the need of an error in the console.